### PR TITLE
Rename the layout update handle to not override enterprise search

### DIFF
--- a/app/code/community/Mpchadwick/SearchAutocompleteConfigmarator/etc/config.xml
+++ b/app/code/community/Mpchadwick/SearchAutocompleteConfigmarator/etc/config.xml
@@ -26,9 +26,9 @@
     <frontend>
         <layout>
             <updates>
-                <enterprise_search>
+                <mpchadwick_searchautocompleteconfigmarator>
                     <file>mpchadwick_searchautocompleteconfigmarator.xml</file>
-                </enterprise_search>
+                </mpchadwick_searchautocompleteconfigmarator>
             </updates>
         </layout>
     </frontend>


### PR DESCRIPTION
This breaks improve-layered-nav (catalinseo) as it overwrites the search.xml layout which in turn removes 'enterprisecatalog.leftnav'. https://github.com/caciobanu/improved-magento-layered-navigation/blob/master/app/code/community/Catalin/SEO/controllers/CategoryController.php#L78
